### PR TITLE
Related to #23, shell scripts should run successfully w/o modification

### DIFF
--- a/prepare_weights/down_base_model.sh
+++ b/prepare_weights/down_base_model.sh
@@ -1,3 +1,3 @@
 git lfs install
-git clone https://huggingface.co/runwayml/stable-diffusion-v1-5 ckpts/Base_Model
+git clone https://huggingface.co/runwayml/stable-diffusion-v1-5 ckpts/Base_Model/stable-diffusion-v1-5
 wget https://huggingface.co/guoyww/animatediff/resolve/main/v3_sd15_mm.ckpt -O ckpts/Base_Model/motion_module/motion_module.ckpt

--- a/prepare_weights/down_magictime_module.sh
+++ b/prepare_weights/down_magictime_module.sh
@@ -1,4 +1,5 @@
 git lfs install
 git clone https://huggingface.co/BestWishYsh/MagicTime
-mv MagicTime/Magic_Weights/ ckpts/
+rm -rf MagicTime/.git
+mv MagicTime/Magic_Weights/* ckpts/Magic_Weights
 rm -r MagicTime


### PR DESCRIPTION
Per discussion in #23 , the two problematic scripts under prepare_weights are fixed such that the clone of the base model is into the correct directory name, and magic time weights are moved without causing errors.  Verified on Ubuntu 22.04.